### PR TITLE
update to use ghcr repo for tkn since it moved

### DIFF
--- a/scaffolder-templates/frontend/manifests/helm/pipeline/templates/job-pipeline-run.yaml
+++ b/scaffolder-templates/frontend/manifests/helm/pipeline/templates/job-pipeline-run.yaml
@@ -3,7 +3,7 @@ kind: Job
 metadata:
   name: {{ .Values.app.name }}-pipeline-run-job
   annotations:
-    argocd.argoproj.io/hook: PostSync 
+    argocd.argoproj.io/hook: PostSync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:
   selector: {}
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: {{ .Values.app.name }}-pipeline-run-job
-          image: gcr.io/tekton-releases/dogfooding/tkn
+          image: ghcr.io/tektoncd/plumbing/tkn
           command:
           - /bin/sh
           - -c

--- a/scaffolder-templates/gateway/manifests/helm/pipeline/templates/job-pipeline-run.yaml
+++ b/scaffolder-templates/gateway/manifests/helm/pipeline/templates/job-pipeline-run.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: {{ .Values.app.name }}-pipeline-run-job
-          image: gcr.io/tekton-releases/dogfooding/tkn
+          image: ghcr.io/tektoncd/plumbing/tkn
           command:
           - /bin/sh
           - -c

--- a/scaffolder-templates/quarkus-backend/manifests/helm/pipeline/templates/job-pipeline-run.yaml
+++ b/scaffolder-templates/quarkus-backend/manifests/helm/pipeline/templates/job-pipeline-run.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: {{ .Values.app.name }}-pipeline-run-job
-          image: gcr.io/tekton-releases/dogfooding/tkn
+          image: ghcr.io/tektoncd/plumbing/tkn
           command:
           - /bin/sh
           - -c

--- a/scaffolder-templates/spring-backend/manifests/helm/pipeline/templates/job-pipeline-run.yaml
+++ b/scaffolder-templates/spring-backend/manifests/helm/pipeline/templates/job-pipeline-run.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: {{ .Values.app.name }}-pipeline-run-job
-          image: gcr.io/tekton-releases/dogfooding/tkn
+          image: ghcr.io/tektoncd/plumbing/tkn
           command:
           - /bin/sh
           - -c


### PR DESCRIPTION
This is due to some [challenges](https://github.com/tektoncd/pipeline/issues/8870) financing the [gcr.io](http://gcr.io/) bandwidth - apparently moving to [ghcr.io](http://ghcr.io/) fixes it: [https://github.com/tektoncd/plumbing/commit/1e8eebb18dcf7462fdcc935fd3d724f97f5cd191#diff-78d00c78dd579e86c3a450660[…]a8911fc2615c53fb2ba4cf5db63L25](https://github.com/tektoncd/plumbing/commit/1e8eebb18dcf7462fdcc935fd3d724f97f5cd191#diff-78d00c78dd579e86c3a450660383bc5ebbcb4a8911fc2615c53fb2ba4cf5db63L25) so I think the fix is to update the container image used for tkn to be [ghcr.io/tektoncd/plumbing/tkn](http://ghcr.io/tektoncd/plumbing/tkn) in [all the places](https://github.com/search?q=repo%3Arh-mad-workshop%2Fcoolstore-software-templates+gcr.io&type=code) it is used